### PR TITLE
Fix warning in qstemplate agent init script

### DIFF
--- a/scripts/init-quickstart-template-agent.sh
+++ b/scripts/init-quickstart-template-agent.sh
@@ -1,24 +1,26 @@
+set -x
+
 # Install Java
-sudo apt-get -y update
-sudo apt-get install -y openjdk-7-jdk
-sudo apt-get update -y --fix-missing
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-7-jdk
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing
 
 # Install git
-sudo apt-get install -y git
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git
 
 # Install python
-sudo apt-get install -y python-pip python-dev libffi-dev libssl-dev
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip python-dev libffi-dev libssl-dev
 sudo pip install virtualenv
 sudo pip install pyparsing
 
 # Install Azure CLI 2.0
 echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
-sudo apt-get install -y apt-transport-https
-sudo apt-get -y update
-sudo apt-get install -y azure-cli
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y azure-cli
 
 # Install Kubernetes CLI
 kubectl_file="/usr/local/bin/kubectl"
-sudo curl -L -s -o $kubectl_file https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+sudo curl -L -o $kubectl_file https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 sudo chmod +x $kubectl_file


### PR DESCRIPTION
The bug in the az cli looks to be fixed, but I was getting a bunch of these warnings:
```
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
```

[This link](http://serverfault.com/questions/227190/how-do-i-ask-apt-get-to-skip-any-interactive-post-install-configuration-steps) had a way to fix the warnings. I also output some more stuff for easier debugging.