### PR TITLE
runIntegrationTests shouldn't be resumable

### DIFF
--- a/src/com/microsoft/azure/devops/ci/utils.groovy
+++ b/src/com/microsoft/azure/devops/ci/utils.groovy
@@ -94,6 +94,7 @@ def loadJobProperties() {
                         node_name - the node name
                         environment - the credentials id for the groovy script that sets up the environment
 */
+@NonCPS
 def runIntegrationTests(envList) {
     Map tasks = [failFast: false]
     for (int i = 0; i < envList.size(); ++i) {


### PR DESCRIPTION
https://github.com/jenkinsci/pipeline-examples/blob/master/docs/BEST_PRACTICES.md
If Jenkins decides to stop and later resume the integration tests steps, then we'll leak test resources