### PR TITLE
Remove quotes around kubeconfig path

### DIFF
--- a/scripts/deploy-quickstart-template.sh
+++ b/scripts/deploy-quickstart-template.sh
@@ -151,7 +151,7 @@ if [[ "$template_name" == *"k8s"* ]]; then
   >&2 echo "Copying Kubernetes credentials to the agent..."
   >&2 az acs kubernetes get-credentials --resource-group=$scenario_name --name=containerservice-$scenario_name --ssh-key-file=$temp_key_path
 
-  if [ ! -s "~/.kube/config" ]; then
+  if [ ! -s ~/.kube/config ]; then
     >&2 echo "Failed to copy kubeconfig for kubernetes cluster."
     exit -1
   fi


### PR DESCRIPTION
The az cli bug was fixed/released, but the path wasn't correct so we were failing for no reason. I verified the tests are passing with this fix