### PR TITLE
Remove 'az logout' from clean deployment script

### DIFF
--- a/scripts/clean-deployments.sh
+++ b/scripts/clean-deployments.sh
@@ -72,5 +72,3 @@ do
     echo "Deleting resource group '$name'."
     az group delete -n $name --yes
 done
- 
-az logout


### PR DESCRIPTION
I moved this to a finally block in the groovy script a few days ago, but forgot to delete it from the script itself.