### PR TITLE
Disable content type auto detection when uploading the hpi

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -65,7 +65,7 @@ def call() {
             }
             stage('Upload Bits') {
                 unstash 'artifacts'
-                azureUpload cntPubAccess: true, containerName: 'devops-jenkins', filesPath: '*.hpi', storageCredentialId: 'devops-public-storage', virtualPath: env.JOB_NAME +'/' +env.BUILD_NUMBER
+                azureUpload blobProperties: [cacheControl: '', contentEncoding: '', contentLanguage: '', contentType: '', detectContentType: false], cntPubAccess: true, containerName: 'devops-jenkins', filesPath: '*.hpi', storageCredentialId: 'devops-public-storage', virtualPath: env.JOB_NAME +'/' +env.BUILD_NUMBER
             }
         }
 


### PR DESCRIPTION
By default the content type detection is on so the hpi files are detected as zip.