### PR TITLE
Use new Azure Credentials pipeline support

### DIFF
--- a/test-solution-template.groovy
+++ b/test-solution-template.groovy
@@ -45,7 +45,7 @@ def DeployJenkinsSolutionTemplate(scenario_name, options) {
         params['storageAccountNewOrExisting'] = ['value' : 'existing']
         def deploy_storage_script_path = 'scripts/deploy-storage-account.sh'
         sh 'sudo chmod +x ' + deploy_storage_script_path
-        withCredentials([usernamePassword(credentialsId: 'AzDevOpsTestingSP', passwordVariable: 'app_key', usernameVariable: 'app_id')]) {
+        withCredentials([azureServicePrincipal(clientIdVariable: 'app_id', clientSecretVariable: 'app_key', credentialsId: 'DevOpsTesting')]) {
             sh deploy_storage_script_path + ' -an ' + params['storageAccountName']['value'] + ' -rg ' + scenario_name + ' -sk ' + params['storageAccountType']['value'] + ' -ai ' + env.app_id + ' -ak ' + env.app_key
         }
     } else {


### PR DESCRIPTION
Updated the solution template test job to use the service principal data instead of the hacky password.