### PR TITLE
Update init scripts to install openJDK 8

### DIFF
--- a/scripts/init-quickstart-template-agent.sh
+++ b/scripts/init-quickstart-template-agent.sh
@@ -1,8 +1,9 @@
 set -x
 
-# Install Java
+# Install Java 8
+sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:openjdk-r/ppa -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk
+sudo DEBIAN_FRONTEND=noninteractive apt-get install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing
 
 # Install git

--- a/scripts/init-ubuntu-dev-agent.sh
+++ b/scripts/init-ubuntu-dev-agent.sh
@@ -1,8 +1,9 @@
 set -x
 
-#Install Java
-sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk
+#Install Java 8
+sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:openjdk-r/ppa -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y update --fix-missing
 
 # Install git


### PR DESCRIPTION
Jenkins 2.60 requires Java 8, so the agents should also have this version (it's backwards compatible, so older Jenkins master will still work)